### PR TITLE
Cannot install alongside PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,9 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle": "^6.2",
+        "guzzlehttp/guzzle": "^6.2"
+    },
+    "require-dev": {
         "phpunit/phpunit": "^5.5"
     },
     "autoload": {


### PR DESCRIPTION
### Problem

`odannyc/google-image-search` cannot be installed alongside PHPUnit 6.

### Root cause

`composer.json` declares `"phpunit/phpunit": "^5.5"` in `require` section. As PHPUnit is a development dependency (not a runtime dependency), it should be declared in the `require-dev` section.

### How to reproduce

1. Create a `composer.json` file containing:
```json
{
    "require": {
        "odannyc/google-image-search": "~1.0"
    },
    "require-dev": {
        "phpunit/phpunit": "~6.0"
    }
}
```
2. Run `composer install`

```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - odannyc/google-image-search v1.0.1 requires phpunit/phpunit ^5.5 -> satisfiable by phpunit/phpunit[5.5.0, 5.5.1, 5.5.2, 5.5.3, 5.5.4, 5.5.5, 5.5.6, 5.5.7, 5.5.x-dev, 5.6.0, 5.6.1, 5.6.2, 5.6.3, 5.6.4, 5.6.5, 5.6.6, 5.6.7, 5.6.8, 5.6.x-dev, 5.7.0, 5.7.1, 5.7.10, 5.7.11, 5.7.12, 5.7.13, 5.7.14, 5.7.15, 5.7.16, 5.7.17, 5.7.18, 5.7.19, 5.7.2, 5.7.20, 5.7.21, 5.7.22, 5.7.23, 5.7.24, 5.7.25, 5.7.3, 5.7.4, 5.7.5, 5.7.6, 5.7.7, 5.7.8, 5.7.9, 5.7.x-dev] but these conflict with your requirements or minimum-stability.
    - odannyc/google-image-search v1.0 requires phpunit/phpunit ^5.5 -> satisfiable by phpunit/phpunit[5.5.0, 5.5.1, 5.5.2, 5.5.3, 5.5.4, 5.5.5, 5.5.6, 5.5.7, 5.5.x-dev, 5.6.0, 5.6.1, 5.6.2, 5.6.3, 5.6.4, 5.6.5, 5.6.6, 5.6.7, 5.6.8, 5.6.x-dev, 5.7.0, 5.7.1, 5.7.10, 5.7.11, 5.7.12, 5.7.13, 5.7.14, 5.7.15, 5.7.16, 5.7.17, 5.7.18, 5.7.19, 5.7.2, 5.7.20, 5.7.21, 5.7.22, 5.7.23, 5.7.24, 5.7.25, 5.7.3, 5.7.4, 5.7.5, 5.7.6, 5.7.7, 5.7.8, 5.7.9, 5.7.x-dev] but these conflict with your requirements or minimum-stability.
    - odannyc/google-image-search v1.0.1 requires phpunit/phpunit ^5.5 -> satisfiable by phpunit/phpunit[5.5.0, 5.5.1, 5.5.2, 5.5.3, 5.5.4, 5.5.5, 5.5.6, 5.5.7, 5.5.x-dev, 5.6.0, 5.6.1, 5.6.2, 5.6.3, 5.6.4, 5.6.5, 5.6.6, 5.6.7, 5.6.8, 5.6.x-dev, 5.7.0, 5.7.1, 5.7.10, 5.7.11, 5.7.12, 5.7.13, 5.7.14, 5.7.15, 5.7.16, 5.7.17, 5.7.18, 5.7.19, 5.7.2, 5.7.20, 5.7.21, 5.7.22, 5.7.23, 5.7.24, 5.7.25, 5.7.3, 5.7.4, 5.7.5, 5.7.6, 5.7.7, 5.7.8, 5.7.9, 5.7.x-dev] but these conflict with your requirements or minimum-stability.
    - Installation request for odannyc/google-image-search ~1.0 -> satisfiable by odannyc/google-image-search[v1.0, v1.0.1].
```

### Fix

This PR moves `phpunit/phpunit` to the `require-dev` section.

---
❤️  Please merge ❤️ 